### PR TITLE
Add 'set -e' to release.sh to abort further processing if anything fails

### DIFF
--- a/release/release.sh
+++ b/release/release.sh
@@ -4,6 +4,8 @@
 #
 # <level> : "major", "minor" or "patch". Default: "minor".
 #
+set -e
+
 BASE_BRANCH="main"
 REPOSITORY="origin"
 NOW_UTC=$(date -u '+%Y%m%d%H%M%S')


### PR DESCRIPTION
This has already created a couple of issues for me as the script simply continues running and creates PRs in git, even though an earlier step failed and there is no chance of anything useful coming out of it.