### PR TITLE
The team that is requested for review does not exist anymore.

### DIFF
--- a/release/release.sh
+++ b/release/release.sh
@@ -27,7 +27,7 @@ maybe_create_github_pr() {
   local TAG=$1
   GH_COMMAND=$(which gh)
   if [ "$GH_COMMAND" != "" ]; then
-    gh pr create --base $BASE_BRANCH --head $RELEASE_BRANCH --reviewer "@stackabletech/rust-developers" --title "Release $TAG" --body "Release $TAG. DO NOT SQUASH MERGE!"
+    gh pr create --base $BASE_BRANCH --head $RELEASE_BRANCH --title "Release $TAG" --body "Release $TAG. DO NOT SQUASH MERGE!"
   fi
 }
 


### PR DESCRIPTION
The team that is requested for review does not exist anymore, which causes the script to fail mid-way when creating a release.

```
➜  operator-rs git:(release-20220117101537) ✗ release.sh
Switched to a new branch 'release-20220117101813'
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
remote:
remote: Create a pull request for 'release-20220117101813' on GitHub by visiting:
remote:      https://github.com/stackabletech/operator-rs/pull/new/release-20220117101813
remote:
To github.com:stackabletech/operator-rs.git
 * [new branch]      release-20220117101813 -> release-20220117101813
Branch 'release-20220117101813' set up to track remote branch 'release-20220117101813' from 'origin'.
    Updating stackable-operator v0.8.0-nightly (/home/sliebau/IdeaProjects/stackable/operator-rs) -> v0.8.0
[release-20220117101813 97c6f6c] bump version 0.8.0
 2 files changed, 4 insertions(+), 1 deletion(-)
    Updating stackable-operator v0.8.0 (/home/sliebau/IdeaProjects/stackable/operator-rs) -> v0.9.0-nightly
[release-20220117101813 0fbc154] bump version 0.9.0-nightly
 1 file changed, 1 insertion(+), 1 deletion(-)
Enumerating objects: 10, done.
Counting objects: 100% (10/10), done.
Delta compression using up to 8 threads
Compressing objects: 100% (7/7), done.
Writing objects: 100% (7/7), 698 bytes | 698.00 KiB/s, done.
Total 7 (delta 5), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (5/5), completed with 3 local objects.
To github.com:stackabletech/operator-rs.git
   db262aa..0fbc154  release-20220117101813 -> release-20220117101813
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 173 bytes | 173.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:stackabletech/operator-rs.git
 * [new tag]         0.8.0 -> 0.8.0
Warning: 1 uncommitted change

Creating pull request for release-20220117101813 into main in stackabletech/operator-rs

could not request reviewer: '@stackabletech/rust-developers' not found
➜  operator-rs git:(release-20220117101813) ✗ cd ~/bin/
```

I'd suggest whoever creates the release manually requests review from the appropriate persons.