### PR TITLE
Do not push release tags automatically anymore.

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -1,10 +1,16 @@
 # Release tools
 
+A set of scripts that automates some release steps. Rougly the release process has three steps:
+
+1. Create a release pull-request containing one commit.
+2. Push the release tag manually (`git push --tags`). Intended to be done after the first step has been merged,
+3. Optional: create a *next development version* pull-request.
+
 ## Install requirements
 
 ### Python 3
 
-A working python 3 installation is required by the cargo-version.py script.
+A working python 3 installation is required by the `cargo-version.py` script.
 
 Install required packages:
 
@@ -18,7 +24,7 @@ Optionally, if you want to have a GitHub Pull-Request automatically created, you
 
 To make a release pull-request, go to the folder containing a Cargo workspace or crate and run:
 
-    release.sh release
+    release.sh [release]
 
 To bump the version and create pull-request:
 
@@ -47,7 +53,7 @@ The release process performs the following steps:
 2. Update `Cargo.lock` with the new version.
 3. Regenerate Helm chart and manifests.
 4. Update the CHANGELOG.md entry of this release
-5. Commit, tag and push the changes.
+5. Commit, tag and push the changes *BUT* do not push the tags.
 6. __Optional__: if the GitHub cli is installed, a PR is created.
 
 Raising the next development version includes the following steps:
@@ -55,5 +61,5 @@ Raising the next development version includes the following steps:
 1. Set the version to the next development version by increasing the 'next-devel-level' (by default) part and adding the '-nightly' prerelease token.
 2. Update `Cargo.lock` with the new version.
 3. Regenerate Helm chart and manifests.
-4. Commit and push
+4. Commit and push *BUT* do not push the tags.
 5. __Optional__: if the GitHub cli is installed, a PR is created.

--- a/release/release.sh
+++ b/release/release.sh
@@ -80,7 +80,7 @@ main() {
 
   if [ "$PUSH" = "true" ]; then
     git push ${REPOSITORY} ${RELEASE_BRANCH} 
-    git push --tags
+    # git push --tags
     maybe_create_github_pr $MESSAGE
     git switch main
   fi


### PR DESCRIPTION
One of the outcomes of today's discussion about the release process was that tags should be pushed manually after the release PRs have been merged.

Related to : https://github.com/stackabletech/issues/issues/178