### PR TITLE
feat: pin docs xref component versions

### DIFF
--- a/release/create-release-branch.sh
+++ b/release/create-release-branch.sh
@@ -109,7 +109,7 @@ main() {
   # check if tag argument provided
   #-----------------------------------------------------------
   if [ -z "${RELEASE}" ]; then
-    echo "Usage: create-release-branch.sh <tag>"
+    echo "Usage: create-release-branch.sh [OPTIONS (see README.md)]"
     exit 1
   fi
   #-----------------------------------------------------------

--- a/release/create-release-tag.sh
+++ b/release/create-release-tag.sh
@@ -158,7 +158,7 @@ update_code() {
     # Replace "nightly" link so the documentation refers to the current version
     #--------------------------------------------------------------------------
     for file in $(find "$1/docs" -name "*.adoc"); do
-      sed -i "s/nightly@home/home/g" "$file"
+      sed -i "s/nightly@home/${RELEASE}@home/g" "$file"
     done
 }
 

--- a/release/create-release-tag.sh
+++ b/release/create-release-tag.sh
@@ -225,7 +225,7 @@ main() {
   # check if tag argument provided
   #-----------------------------------------------------------
   if [ -z "${RELEASE_TAG}" ]; then
-    echo "Usage: create-release-tag.sh -t <tag>"
+    echo "Usage: create-release-tag.sh [OPTIONS (see README.md)]"
     exit 1
   fi
   #-----------------------------------------------------------


### PR DESCRIPTION
After giving component links a bit more thought, I realized we should pin the versions. I didn't test this change. It should change links from 

    xref:nightly@home:...

to

    xref:23.1@home:...

How can I test this, or can someone test it for me :grimacing: ?