### PR TITLE
Generate catalog/subscriptions from olm bundles for openshift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 olm/catalog.Dockerfile
 olm/catalog/
 olm/subscriptions/
+olm/catalog-source.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /.idea
+olm/catalog.Dockerfile
+olm/catalog/
+olm/subscriptions/

--- a/olm/README.md
+++ b/olm/README.md
@@ -1,0 +1,123 @@
+# OLM installation files
+
+The following steps describe how to install a Stackable operator - in this, the operator for Apache Zookeeper - using the [Operator Lifecycle Manager](https://olm.operatorframework.io/) (OLM).
+
+It specifically installs the version 23.1.0 of the operator. Installing additional versions in the future requires generating new bundle images and updating the catalog as described below.
+
+## Usage
+
+Prerequisite is of course a running OpenShift cluster.
+
+First, install the operator using OLM:
+
+    kubectl apply -f catalog-source.yaml \
+    -f operator-group.yaml \
+    -f subscription.yaml
+
+Then, install the operator dependencies with Helm:
+
+    helm install secret-operator stackable/secret-operator
+    helm install commons-operator stackable/commons-operator
+
+And finally, create an Apache Zookeeper cluster:
+
+    kubectl create -f examples/simple-zookeeper-cluster.yaml
+
+NOTE: The `kuttl` tests don't work because they themselves require SCCs which are not available.
+
+## OLM packaging requirements
+
+- An [OpenShift](https://developers.redhat.com/products/openshift-local/overview) cluster.
+- [opm](https://github.com/operator-framework/operator-registry/)
+- docker and kubectl
+- `kubeadmin` access
+
+It was tested with:
+
+    $ crc version
+    WARN A new version (2.5.1) has been published on https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/2.5.1/crc-linux-amd64.tar.xz
+    CRC version: 2.4.1+b877358
+    OpenShift version: 4.10.14
+    Podman version: 4.0.2
+
+    $ oc version
+    Client Version: 4.10.14
+    Server Version: 4.10.14
+    Kubernetes Version: v1.23.5+b463d71
+
+    $ opm version
+    Version: version.Version{OpmVersion:"v1.23.2", GitCommit:"82505333", BuildDate:"2022-07-04T13:45:39Z", GoOs:"linux", GoArch:"amd64"}
+
+## Open questions
+
+- OLM [doesn't support DaemonSet(s)](https://github.com/operator-framework/operator-lifecycle-manager/issues/1022) and we need them for the secret-operator. Currently we can deploy the secret-operator using Helm but this means we cannot configure the [required](https://olm.operatorframework.io/docs/tasks/creating-operator-manifests/#required-apis) apis of the Zookeeper bundle. What are the consequences for publishing and certification ?
+- Here we create a catalog for a single operator. We probably want a catalog for all Stackable operators in the future but this will get large very quickly. Figure out how to handle this. Especially figure out what happens with new versions of the same operator.
+- OLM cannot create SecurityContextConstraints objects. The Zookeeper cluster (not the operator) cannot run with the default `restricted` SCC. The current solution is to use the `hostmount-anyuid` SCC for the `zookeeper-clusterrole`. Will this pass the certification process ?
+- Everything (catalog, subscription, etc) is installed in the `stackable-operators` namespace. Is this a good idea ?
+- The Subscription object uses `installPlanApproval: Automatic` which means the operator is updated automatically for every new version. Is this a good idea?
+
+See the [OLM documentation](https://olm.operatorframework.io/docs/tasks/) for details.
+
+## Build and publish operator bundle image
+
+Each catalog can contain several operator packages, and each operator package can contain multiple channels, each with its own bundles of different versions of the operator.
+
+### Generate operator bundle (this is operator-specific)
+
+    opm alpha bundle generate --directory manifests --package zookeeper-operator-package --output-dir bundle --channels stable --default stable
+
+### Build bundle image
+
+    docker build -t docker.stackable.tech/stackable/zookeeper-operator-bundle:23.1.0 -f bundle.Dockerfile .
+  	docker push docker.stackable.tech/stackable/zookeeper-operator-bundle:23.1.0
+
+### Validate bundle image
+
+  	opm alpha bundle validate --tag docker.stackable.tech/stackable/zookeeper-operator-bundle:23.1.0 --image-builder docker
+
+## Create catalog
+
+    mkdir catalog
+    opm generate dockerfile catalog
+
+## Create a package for each operator
+
+    opm init zookeeper-operator-package \
+      --default-channel=stable \
+      --description=./README.md \
+      --output yaml > catalog/zookeeper-operator-package.yaml
+
+    {
+        echo "---"
+        echo "schema: olm.channel"
+        echo "package: zookeeper-operator-package"
+        echo "name: stable"
+        echo "entries:"
+        echo "- name: zookeeper-operator.v23.1.0"
+    } >> catalog/zookeeper-operator-package.yaml
+
+NOTE: with the command below we can add the Stackable logo as icon.
+
+    # add for each operator...
+    opm render docker.stackable.tech/stackable/zookeeper-operator-bundle:23.1.0 --output=yaml >> catalog/zookeeper-operator-package.yaml
+
+    # ...and then validate the entire catalog
+    opm validate catalog
+
+The catalog is correct if the command above returns successfully without any message. If the catalog doesn't validate, the operator will not install. Now build a catalog image and push it to the repository:
+
+    docker build .  -f catalog.Dockerfile -t docker.stackable.tech/stackable/zookeeper-operator-catalog:latest
+    docker push docker.stackable.tech/stackable/zookeeper-operator-catalog:latest
+
+## Install catalog and the operator group
+
+    kubectl apply -f catalog-source.yaml
+    kubectl apply -f operator-group.yaml
+
+## List available operators
+
+    kubectl get packagemanifest -n stackable-operators
+
+## Install operator
+
+    kubectl apply -f subscription.yaml

--- a/olm/build-catalog.sh
+++ b/olm/build-catalog.sh
@@ -1,15 +1,31 @@
 #!/usr/bin/env bash
+# Usage:
+#   ./olm/build-catalog.sh <release as x.y.z> [-n] [-s]
+#   -r <release>: the release number (mandatory). This must be a semver-compatible value to patch-level e.g. 23.1.0.
+#   -n: create namespace stackable-operators (optional, default is "false").
+#   -s: deploy subscriptions (optional, default is "false").
 
 set -euo pipefail
 set -x
 
-main() {
-  VERSION="$1";
 
-  pushd olm
-  echo "Deploy custom scc..."
-  kubectl apply -f scc.yaml
+parse_inputs() {
+  VERSION=""
+  NAMESPACE=false
+  SUBSCRIPTIONS=false
 
+  while [[ "$#" -gt 0 ]]; do
+      case $1 in
+          -r|--release) VERSION="$2"; shift ;;
+          -n|--namespace) NAMESPACE=true ;;
+          -s|--subscriptions) SUBSCRIPTIONS=true ;;
+          *) echo "Unknown parameter passed: $1"; exit 1 ;;
+      esac
+      shift
+  done
+}
+
+setup() {
   if [ -d "catalog" ]; then
     rm -rf catalog
   fi
@@ -17,10 +33,22 @@ main() {
     rm -rf subscriptions
   fi
 
-  # catalog (just creates dockerfile with copy command)
   mkdir -p catalog
   mkdir -p subscriptions
   rm -f catalog.Dockerfile
+}
+
+prerequisites() {
+  echo "Deploy custom scc..."
+  kubectl apply -f scc.yaml
+
+  if $NAMESPACE; then
+    echo "Creating namespace..."
+    kubectl apply -f namespace.yaml
+  fi
+}
+
+catalog() {
   opm generate dockerfile catalog
 
   # iterate over operators
@@ -50,11 +78,9 @@ main() {
   echo "Build and push catalog for all operators..."
   docker build . -f catalog.Dockerfile -t "docker.stackable.tech/stackable/stackable-operators-catalog:${VERSION}"
   docker push "docker.stackable.tech/stackable/stackable-operators-catalog:${VERSION}"
+}
 
-  # install catalog/group for all operators
-  #kubectl apply -f catalog-source.yaml
-  #kubectl apply -f operator-group.yaml
-
+subscriptions() {
   # iterate over operator list to deploy
   while IFS="" read -r operator || [ -n "$operator" ]
   do
@@ -73,8 +99,30 @@ main() {
     echo "  sourceNamespace: stackable-operators"
     echo "  installPlanApproval: Automatic"
     } >> "subscriptions/$operator-subscription.yaml"
-    # kubectl apply -f "subscriptions/$operator-subscription.yaml"
+    if $SUBSCRIPTIONS; then
+      kubectl apply -f "subscriptions/$operator-subscription.yaml"
+    fi
   done < <(yq '... comments="" | .operators[] ' config.yaml)
+}
+
+main() {
+  parse_inputs "$@"
+  if [ -z "${VERSION}" ]; then
+    echo "Usage: build-catalog.sh -r <release>"
+    exit 1
+  fi
+
+  pushd olm
+
+  setup
+  prerequisites
+  catalog
+
+  # install catalog/group for all operators
+  kubectl apply -f catalog-source.yaml
+  kubectl apply -f operator-group.yaml
+
+  subscriptions
 
   popd
   echo "Deployment successful!"

--- a/olm/build-catalog.sh
+++ b/olm/build-catalog.sh
@@ -120,7 +120,7 @@ deploy() {
     echo "  namespace: stackable-operators"
     echo "spec:"
     echo "  sourceType: grpc"
-    echo "  image: docker.stackable.tech/sandbox/test/stackable-operators-catalog:${VERSION}"
+    echo "  image: docker.stackable.tech/stackable/stackable-operators-catalog:${VERSION}"
     echo "  displayName: Stackable Catalog"
     echo "  publisher: Stackable GmbH"
     echo "  updateStrategy:"

--- a/olm/build_catalog.sh
+++ b/olm/build_catalog.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+main() {
+  VERSION="$1";
+
+  pushd olm
+  echo "Deploy custom scc..."
+  kubectl apply -f scc.yaml
+
+  if [ -d "catalog" ]; then
+    rm -rf catalog
+  fi
+  if [ -d "subscriptions" ]; then
+    rm -rf subscriptions
+  fi
+
+  # catalog (just creates dockerfile with copy command)
+  mkdir -p catalog
+  mkdir -p subscriptions
+  rm -f catalog.Dockerfile
+  opm generate dockerfile catalog
+
+  # iterate over operators
+  while IFS="" read -r operator || [ -n "$operator" ]
+  do
+    echo "Initiating package: ${operator}"
+    opm init "${operator}-operator-package" \
+        --default-channel=stable \
+        --description=./README.md \
+        --output yaml > "catalog/${operator}-operator-package.yaml"
+    echo "Add operator to package: ${operator}"
+    {
+      echo "---"
+      echo "schema: olm.channel"
+      echo "package: ${operator}-operator-package"
+      echo "name: stable"
+      echo "entries:"
+      echo "- name: ${operator}-operator.v${VERSION}"
+    } >> "catalog/${operator}-operator-package.yaml"
+    echo "Render operator: ${operator}"
+    opm render "docker.stackable.tech/stackable/${operator}-operator-bundle:${VERSION}" --output=yaml >> "catalog/${operator}-operator-package.yaml"
+  done < <(yq '... comments="" | .operators[] ' config.yaml)
+
+  echo "Validating catalog..."
+  opm validate catalog
+
+  echo "Build and push catalog for all operators..."
+  docker build . -f catalog.Dockerfile -t "docker.stackable.tech/stackable/stackable-operators-catalog:${VERSION}"
+  docker push "docker.stackable.tech/stackable/stackable-operators-catalog:${VERSION}"
+
+  # install catalog/group for all operators
+  #kubectl apply -f catalog-source.yaml
+  #kubectl apply -f operator-group.yaml
+
+  # iterate over operator list to deploy
+  while IFS="" read -r operator || [ -n "$operator" ]
+  do
+    echo "Deploy subscription: ${operator}"
+    {
+    echo "---"
+    echo "apiVersion: operators.coreos.com/v1alpha1"
+    echo "kind: Subscription"
+    echo "metadata:"
+    echo "  name: $operator-operator-subscription"
+    echo "  namespace: stackable-operators"
+    echo "spec:"
+    echo "  channel: stable"
+    echo "  name: $operator-operator-package"
+    echo "  source: stackable-operators-catalog"
+    echo "  sourceNamespace: stackable-operators"
+    echo "  installPlanApproval: Automatic"
+    } >> "subscriptions/$operator-subscription.yaml"
+    # kubectl apply -f "subscriptions/$operator-subscription.yaml"
+  done < <(yq '... comments="" | .operators[] ' config.yaml)
+
+  popd
+  echo "Deployment successful!"
+}
+
+main "$@"

--- a/olm/catalog-source.yaml
+++ b/olm/catalog-source.yaml
@@ -1,11 +1,4 @@
 ---
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: stackable-operators
-  labels:
-    name: stackable-operators
----
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:

--- a/olm/catalog-source.yaml
+++ b/olm/catalog-source.yaml
@@ -1,0 +1,21 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: stackable-operators
+  labels:
+    name: stackable-operators
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: stackable-operators-catalog
+  namespace: stackable-operators
+spec:
+  sourceType: grpc
+  image: docker.stackable.tech/sandbox/test/stackable-operators-catalog:23.1.0
+  displayName: Stackable Catalog
+  publisher: Stackable GmbH
+  updateStrategy:
+    registryPoll:
+      interval: 10m

--- a/olm/config.yaml
+++ b/olm/config.yaml
@@ -1,0 +1,4 @@
+---
+operators:
+  - commons
+  - zookeeper

--- a/olm/namespace.yaml
+++ b/olm/namespace.yaml
@@ -1,0 +1,8 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: stackable-operators
+  labels:
+    name: stackable-operators
+

--- a/olm/operator-group.yaml
+++ b/olm/operator-group.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: stackable-operators-group
+  namespace: stackable-operators
+spec:
+  targetNamespaces:
+    - stackable-operators

--- a/olm/scc.yaml
+++ b/olm/scc.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: zookeeper-scc
+  annotations:
+    kubernetes.io/description: |-
+      zookeeper-scc is derived from hostmount-anyuid. It provides all the features of the
+      restricted SCC but allows host mounts and any UID by a pod.  This is primarily
+      used by the persistent volume recycler. WARNING: this SCC allows host file
+      system access as any UID, including UID 0.  Grant with caution.
+    release.openshift.io/create-only: "true"
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - hostPath
+  - nfs
+  - persistentVolumeClaim
+  - projected
+  - secret
+  - ephemeral

--- a/olm/scc.yaml
+++ b/olm/scc.yaml
@@ -2,10 +2,10 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: zookeeper-scc
+  name: stackable-platform-scc
   annotations:
     kubernetes.io/description: |-
-      zookeeper-scc is derived from hostmount-anyuid. It provides all the features of the
+      stackable-platform-scc is derived from hostmount-anyuid. It provides all the features of the
       restricted SCC but allows host mounts and any UID by a pod.  This is primarily
       used by the persistent volume recycler. WARNING: this SCC allows host file
       system access as any UID, including UID 0.  Grant with caution.


### PR DESCRIPTION
Adds a new script for combining operator bundles into a catalog, with the option of deploying operator subscriptions.