### PR TITLE
pre-23.7-release changes

### DIFF
--- a/release/README.adoc
+++ b/release/README.adoc
@@ -56,7 +56,7 @@ To create release branches use the `create-release-branch.sh` script, called fro
 ----
 
 - `-b <release>`: the release number (mandatory). This must be a semver-compatible value (i.e. without leading zeros) such as `23.1`, `23.10` etc. and will be used to create a branch with the name `release-<release>` e.g. `release-23.1`
-- `-p`: push flag (optional, default is "false"). If provided, the created branches plus any changes made as part fo this process will be pushed to the origin.
+- `-p`: push flag (optional, default is "false"). If provided, the created branches plus any changes made as part of this process will be pushed to the origin.
 - `-c`: cleanup flag (optional, default is "false"). If provided, the repository folders will be torn down on completion.
 - `-w`: where to create the branch. It can be "products", "operators", "both".
 
@@ -141,11 +141,6 @@ Some post release steps are performed with `release/post-release.sh` script, cal
 - `-t <release-tag>`: the release tag (mandatory). This must be a semver-compatible value (i.e. major/minor/path, without leading zeros) such as `23.1.0`, `23.10.3` etc. and will be used to create a tag with the name
 - `-p`: push flag (optional, default is "false"). If provided, the created commits and tags made as part of this process will be pushed to the origin.
 
-[source]
-----
-./release/create-release-tag.sh -t 23.1.0 -p -c
-----
-
 #### What this script does
 
 * checks that the release tag exists and that the all operator repositories have a clean working copy
@@ -206,7 +201,7 @@ To create release tags for bugfix/patch releases use the `create-bugfix-tag.sh` 
 
 [source]
 ----
-./release/create-bugfix-tag.sh -t <release-tag> [-p] [-c] [-w products|operators|both]
+./release/create-bugfix-tag.sh -t <release-tag> [-p] [-c] [-w products|operators|both] [-i]
 ----
 
 - `-t <release-tag>`: the release tag (mandatory). This must be a semver-compatible value (i.e. major/minor/path, without leading zeros) such as `23.1.0`, `23.10.3` etc. and will be used to create a tag with the name

--- a/release/create-bugfix-tag.sh
+++ b/release/create-bugfix-tag.sh
@@ -126,7 +126,7 @@ update_code() {
   if $PRODUCT_IMAGE_TAGS; then
     echo "Updating relase tag in code..."
     if [ -f "$TEMP_RELEASE_FOLDER/$1/tests/test-definition.yaml" ]; then
-      # e.g. 2.2.4-stackable0.5.0 -> 2.2.4-stackable23.1
+      # e.g. 2.2.4-stackable23.1 -> 2.2.4-stackable23.1.1, since the release tag will use major.minor only
       sed -i "s/-stackable.*/-stackable${RELEASE_TAG}/" "$TEMP_RELEASE_FOLDER/$1/tests/test-definition.yaml"
     fi
   else

--- a/release/create-release-branch.sh
+++ b/release/create-release-branch.sh
@@ -109,7 +109,7 @@ main() {
   # check if tag argument provided
   #-----------------------------------------------------------
   if [ -z "${RELEASE}" ]; then
-    echo "Usage: create-release-branch.sh <tag>"
+    echo "Usage: create-release-branch.sh -b <branch> [-p] [-c] [-w both|products|operators]"
     exit 1
   fi
   #-----------------------------------------------------------

--- a/release/create-release-tag.sh
+++ b/release/create-release-tag.sh
@@ -133,7 +133,7 @@ update_code() {
   # Not all operators have a getting started guide
   # that's why we verify if templating_vars.yaml exists.
   if [ -f "$1/docs/templating_vars.yaml" ]; then
-    yq -i "(.versions.[] | select(. == \"*dev\")) |= \"${RELEASE_TAG}\"" "$1/docs/templating_vars.yaml"
+    yq -i "(.versions.[] | select(. == \"*dev\")) |= \"${RELEASE}\"" "$1/docs/templating_vars.yaml"
     yq -i ".helm.repo_name |= sub(\"stackable-dev\", \"stackable-stable\")" "$1/docs/templating_vars.yaml"
     yq -i ".helm.repo_url |= sub(\"helm-dev\", \"helm-stable\")" "$1/docs/templating_vars.yaml"
   fi
@@ -144,7 +144,7 @@ update_code() {
   #--------------------------------------------------------------------------
   if [ -d "$1/docs/modules/getting_started/examples/code" ]; then
     for file in $(find "$1/docs/modules/getting_started/examples/code" -name "*.yaml"); do
-      yq -i "(.spec | select(has(\"image\")).image | (select(has(\"stackableVersion\")).stackableVersion)) = \"${RELEASE_TAG}\"" "$file"
+      yq -i "(.spec | select(has(\"image\")).image | (select(has(\"stackableVersion\")).stackableVersion)) = \"${RELEASE}\"" "$file"
     done
   fi
 
@@ -155,7 +155,7 @@ update_code() {
     # TODO old product images won't be tested any longer
     if [ -f "$1/tests/test-definition.yaml" ]; then
       # e.g. 2.2.4-stackable0.5.0 -> 2.2.4-stackable23.1
-      sed -i "s/-stackable.*/-stackable${RELEASE_TAG}/" "$1/tests/test-definition.yaml"
+      sed -i "s/-stackable.*/-stackable${RELEASE}/" "$1/tests/test-definition.yaml"
     fi
 
     #--------------------------------------------------------------------------
@@ -234,7 +234,7 @@ main() {
   # check if tag argument provided
   #-----------------------------------------------------------
   if [ -z "${RELEASE_TAG}" ]; then
-    echo "Usage: create-release-tag.sh -t <tag>"
+    echo "Usage: create-release-tag.sh -t <tag> [-p] [-c] [-w both|products|operators]"
     exit 1
   fi
   #-----------------------------------------------------------


### PR DESCRIPTION
For tests & getting-started scripts the products will be tagged with major.minor e.g. 23.7 instrad of 23.7.1. This will make bugfixes easier.