### PR TITLE
Added check to bulk pr scripts to bail if no parameter is given when running the scripts

### DIFF
--- a/bulk-pr/pr_approve
+++ b/bulk-pr/pr_approve
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 PR_BRANCH_NAME=${1:?Must provide name of PR branch to operate on.}
 source repos
 for product in "${products[@]}"; do

--- a/bulk-pr/pr_approve
+++ b/bulk-pr/pr_approve
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+PR_BRANCH_NAME=${1:?Must provide name of PR branch to operate on.}
 source repos
 for product in "${products[@]}"; do
-  STATE=$(gh pr view $1  -R stackabletech/${product}-operator --jq '.state' --json state)
+  STATE=$(gh pr view ${PR_BRANCH_NAME}  -R stackabletech/${product}-operator --jq '.state' --json state)
   if [[ $STATE -eq "OPEN" ]]; then
     echo "Approving ${product}"
-    gh pr review $1 --approve -R stackabletech/${product}-operator
-    gh pr merge $1 -R stackabletech/${product}-operator
+    gh pr review ${PR_BRANCH_NAME} --approve -R stackabletech/${product}-operator
+    gh pr merge ${PR_BRANCH_NAME} -R stackabletech/${product}-operator
   else
     echo "Skipping ${product}, PR already closed"
   fi

--- a/bulk-pr/pr_checks
+++ b/bulk-pr/pr_checks
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+PR_BRANCH_NAME=${1:?Must provide name of PR branch to operate on.}
 source repos
 for product in "${products[@]}"; do
-    gh pr checks $1 -R stackabletech/${product}-operator 
+    gh pr checks ${PR_BRANCH_NAME} -R stackabletech/${product}-operator
 done
 

--- a/bulk-pr/pr_checks
+++ b/bulk-pr/pr_checks
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 PR_BRANCH_NAME=${1:?Must provide name of PR branch to operate on.}
 source repos
 for product in "${products[@]}"; do

--- a/bulk-pr/pr_close
+++ b/bulk-pr/pr_close
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 PR_BRANCH_NAME=${1:?Must provide name of PR branch to operate on.}
 source repos
 for product in "${products[@]}"; do

--- a/bulk-pr/pr_close
+++ b/bulk-pr/pr_close
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+PR_BRANCH_NAME=${1:?Must provide name of PR branch to operate on.}
 source repos
 for product in "${products[@]}"; do
-    STATE=$(gh pr view $1  -R stackabletech/${product}-operator --jq '.state' --json state)
+    STATE=$(gh pr view ${PR_BRANCH_NAME}  -R stackabletech/${product}-operator --jq '.state' --json state)
     if [[ $STATE -eq "OPEN" ]]; then
-        gh pr close $1 -R stackabletech/${product}-operator
+        gh pr close ${PR_BRANCH_NAME} -R stackabletech/${product}-operator
     else
         echo "Skipping ${product}, PR already closed"
     fi

--- a/bulk-pr/pr_diffs
+++ b/bulk-pr/pr_diffs
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+PR_BRANCH_NAME=${1:?Must provide name of PR branch to operate on.}
 source repos
 for product in "${products[@]}"; do
-    gh pr diff $1 -R stackabletech/${product}-operator
+    gh pr diff ${PR_BRANCH_NAME} -R stackabletech/${product}-operator
 done
 

--- a/bulk-pr/pr_diffs
+++ b/bulk-pr/pr_diffs
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 PR_BRANCH_NAME=${1:?Must provide name of PR branch to operate on.}
 source repos
 for product in "${products[@]}"; do

--- a/bulk-pr/pr_list
+++ b/bulk-pr/pr_list
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+PR_BRANCH_NAME=${1:?Must provide name of PR branch to operate on.}
 source repos
 # Disable gh paging for results.
 PAGER=

--- a/bulk-pr/pr_list
+++ b/bulk-pr/pr_list
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 PR_BRANCH_NAME=${1:?Must provide name of PR branch to operate on.}
 source repos
 # Disable gh paging for results.

--- a/bulk-pr/pr_status
+++ b/bulk-pr/pr_status
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 PR_BRANCH_NAME=${1:?Must provide name of PR branch to operate on.}
 source repos
 for product in "${products[@]}"; do

--- a/bulk-pr/pr_status
+++ b/bulk-pr/pr_status
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
+PR_BRANCH_NAME=${1:?Must provide name of PR branch to operate on.}
 source repos
 for product in "${products[@]}"; do
-    STATE=$(gh pr view $1  -R stackabletech/${product}-operator --jq '.state' --json state)
-    gh pr checks $1 -R stackabletech/${product}-operator &> /dev/null
+    STATE=$(gh pr view ${PR_BRANCH_NAME}  -R stackabletech/${product}-operator --jq '.state' --json state)
+    gh pr checks ${PR_BRANCH_NAME} -R stackabletech/${product}-operator &> /dev/null
     status=$?
     echo "${product}(${STATE}): ${status}"
 done


### PR DESCRIPTION
All of these scripts require the branch name the prs are based on to work and will not do any work otherwise.