### PR TITLE
Release 24.7 changes/fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ olm/catalog/
 olm/subscriptions/
 olm/catalog-source.yaml
 stackable-bcrypt/target
+
+# Nix stuff
+.envrc
+.direnv

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ See relevant READMEs:
 - [PR Bulk Tools](./bulk-pr/READMEOverview.md)
 - [OLM Overview](./olm/README.md)
 - [Stackable Quickstart](./quickstart/README.md)
-- [Release Workflow](./release/README.adoc)
+- [Release Workflow](./release/README.md)
 - [Renovate](./renovate/README.md)
 - [BCrypt Tool](./stackable-bcrypt/README.md)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # stackable-utils
+
+See relevant READMEs:
+
+- [PR Bulk Tools](./bulk-pr/READMEOverview.md)
+- [OLM Overview](./olm/README.md)
+- [Stackable Quickstart](./quickstart/README.md)
+- [Release Workflow](./release/README.adoc)
+- [Renovate](./renovate/README.md)
+- [BCrypt Tool](./stackable-bcrypt/README.md)

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -1,30 +1,30 @@
 # Release workflow
 
-This is the recommended release flow in a nutshell for the release 24.3:
+This is the recommended release flow in a nutshell for the release 24.7:
 
 [source,bash]
 ----
 # start with the product images ...
 # create and push the release branch
-./release/create-release-branch.sh -b 24.3 -w products -p
+./release/create-release-branch.sh -b 24.7 -w products # Only add the -p flag after testing locally first
 
 # create and push the release tag
-./release/create-release-tag.sh -t 24.3.0 -w products -p
+./release/create-release-tag.sh -t 24.7.0 -w products # Only add the -p flag after testing locally first
 
 # monitor the GH action that builds ~80 images for success
 
 # continue with the operators ...
 # create and push the release branch
-./release/create-release-branch.sh -b 24.3 -w operators -p
+./release/create-release-branch.sh -b 24.7 -w operators # Only add the -p flag after testing locally first
 
 # create and push the release tag
-./release/create-release-tag.sh -t 24.3.0 -w operators -p
+./release/create-release-tag.sh -t 24.7.0 -w operators # Only add the -p flag after testing locally first
 
 # monitor the GH actions that build the operator images for success
 
 # finally patch the changelog file in the main branch
 # create PRs for all operators
-./release/post-release.sh -t 24.3.0 -p
+./release/post-release.sh -t 24.7.0 # Only add the -p flag after testing locally first
 
 # and that is it!
 # (now the tedious post release steps start ...)

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -2,6 +2,7 @@
 
 This is the recommended release flow in a nutshell for the release 24.3:
 
+[source,bash]
 ----
 # start with the product images ...
 # create and push the release branch

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -104,7 +104,7 @@ e.g.
 
 [source]
 ----
-./release/create-release-branch.sh -b 23.1 -c -w both
+./release/create-release-branch.sh -b 23.1 -p -c -w both
 ----
 
 ##### What this script does
@@ -144,7 +144,7 @@ e.g.
 
 [source]
 ----
-./release/create-release-tag.sh -t 23.1.0 -c -w both
+./release/create-release-tag.sh -t 23.1.0 -p -c -w both
 ----
 
 ##### What this script does
@@ -257,7 +257,7 @@ e.g.
 
 [source]
 ----
-./release/create-bugfix-tag.sh -t 23.1.0 -c -w both -i
+./release/create-bugfix-tag.sh -t 23.1.0 -p -c -w both -i
 ----
 
 ##### What this script does

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -10,7 +10,7 @@ This is the recommended release flow in a nutshell for the release 24.3:
 # create and push the release tag
 ./release/create-release-tag.sh -t 24.3.0 -w products -p
 
-# monior the GH action that builds ~80 images for success
+# monitor the GH action that builds ~80 images for success
 
 # continue with the operators ...
 # create and push the release branch
@@ -19,7 +19,7 @@ This is the recommended release flow in a nutshell for the release 24.3:
 # create and push the release tag
 ./release/create-release-tag.sh -t 24.3.0 -w operators -p
 
-# monior the GH actions that build the oeprator images for success
+# monitor the GH actions that build the operator images for success
 
 # finally patch the changelog file in the main branch
 # create PRs for all operators
@@ -69,7 +69,7 @@ Install it like this:
 
 [source,bash]
 ----
-cargo install cargo-edit --version 0.11.11
+cargo install cargo-edit --version 0.12.3
 ----
 
 ### yq (yaml parser)

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -30,7 +30,7 @@ This is the recommended release flow in a nutshell for the release 24.3:
 # (now the tedious post release steps start ...)
 ----
 
-# Release scripts
+## Release scripts
 
 A set of scripts that automates some release steps. The release process has multiple steps:
 
@@ -59,9 +59,9 @@ A set of scripts that automates some release steps. The release process has mult
 
 image::images/rb-utils.png[]
 
-## Install requirements
+### Install requirements
 
-### cargo-edit plugin
+#### cargo-edit plugin
 
 
 The `cargo-edit` plugin is used to update operator versions in `cargo` workspaces.
@@ -73,18 +73,18 @@ Install it like this:
 cargo install cargo-edit --version 0.12.3
 ----
 
-### yq (yaml parser)
+#### yq (yaml parser)
 
 This script requires https://github.com/mikefarah/yq (not to be confused with https://github.com/kislyuk/yq).
 
-### gh (github client)
+#### gh (github client)
 
 This script requires https://github.com/cli to be installed.
 You have to be logged in when running the `post-release.sh` script. The easiest way is to have a local env variable `GH_TOKEN` set to a classic token created via https://github.com/settings/tokens with all `repo` and all `admin:org` scopes or follow the login instructions here https://cli.github.com/manual/gh_auth_login.
 
-## Usage
+### Usage
 
-### Release branches
+#### Release branches
 
 To create release branches use the `create-release-branch.sh` script, called from the repository root folder. The syntax is given below:
 
@@ -104,10 +104,10 @@ e.g.
 
 [source]
 ----
-./release/create-release-branch.sh -b 23.1 -p -c -w both
+./release/create-release-branch.sh -b 23.1 -c -w both
 ----
 
-#### What this script does
+##### What this script does
 
 * checks that the release argument is valid (e.g. semver-compatible, just major/minor levels)
 * strips this argument of any leading or trailing quote marks
@@ -124,7 +124,7 @@ e.g.
 ** deletes the temporary folder (if requested with "-c")
 
 
-### Release tags
+#### Release tags
 
 To create release tags use the `create-release-tag.sh` script, called from the repository root folder. The syntax is given below:
 
@@ -144,10 +144,10 @@ e.g.
 
 [source]
 ----
-./release/create-release-tag.sh -t 23.1.0 -p -c -w both
+./release/create-release-tag.sh -t 23.1.0 -c -w both
 ----
 
-#### What this script does
+##### What this script does
 
 * checks that the release argument is valid (e.g. semver-compatible, major/minor/patch levels)
 * for docker images:
@@ -166,7 +166,7 @@ e.g.
 ** pushes the commit and tag (if requested with "-p")
 ** deletes the temporary folder (if requested with "-c")
 
-### Post-release steps
+#### Post-release steps
 
 Some post release steps are performed with `release/post-release.sh` script, called from the repository root folder. The syntax is given below:
 
@@ -178,17 +178,17 @@ Some post release steps are performed with `release/post-release.sh` script, cal
 - `-t <release-tag>`: the release tag (mandatory). This must be a semver-compatible value (i.e. major/minor/path, without leading zeros) such as `23.1.0`, `23.10.3` etc. and will be used to create a tag with the name
 - `-p`: push flag (optional, default is "false"). If provided, the created commits and tags made as part of this process will be pushed to the origin.
 
-#### What this script does
+##### What this script does
 
 * checks that the release tag exists and that the all operator repositories have a clean working copy
 * merges the CHANGELOG.md from the release tag into main
 * creates PRs for all operators
 
-#### Build actions
+##### Build actions
 
 When a tag is pushed, the images for products and operators are built via github actions. The following points should be noted:
 
-##### Product images
+###### Product images
 
 The build action script `release.yml` builds all product images that defined in the `release.yaml` matrix section:
 
@@ -218,7 +218,7 @@ Base images should be excluded from the build action as they need to be referenc
 
 Also note that the tag pattern above is not using a regex (this functionality is not available for tag filtering) but uses glob-operators. The check is not totally watertight - we cannot for example enforce the "minor" version of the release to be limited to a digit between 1 and 12 - but this check is covered by the calling script `create-release-tag.sh`.
 
-##### Operator images
+###### Operator images
 
 Operator images are built by iterating over and pushing tags for the operator-repositories listed in the `operators` section of `config.yaml`:
 
@@ -232,11 +232,11 @@ images-repo: docker-images
     - ...
 ----
 
-### Post-release steps
+#### Post-release steps
 
 Once the release is complete and all steps above have been verified, the documentation needs to be updated and built. This is done in a separate suite of scripts found https://github.com/stackabletech/documentation/tree/main/scripts[here]. Follow the steps given in the two scripts (there are prompts provided which allow for early-exit if things are not as they should be!).
 
-### Bugfix/patch tags
+#### Bugfix/patch tags
 
 To create release tags for bugfix/patch releases use the `create-bugfix-tag.sh` script, called from the repository root folder. The syntax is given below:
 
@@ -257,10 +257,10 @@ e.g.
 
 [source]
 ----
-./release/create-bugfix-tag.sh -t 23.1.0 -p -c -w both -i
+./release/create-bugfix-tag.sh -t 23.1.0 -c -w both -i
 ----
 
-#### What this script does
+##### What this script does
 
 * checks that the release argument is valid (e.g. semver-compatible, major/minor/patch levels)
 * strips this argument of any leading or trailing quote marks

--- a/release/README.md
+++ b/release/README.md
@@ -2,8 +2,7 @@
 
 This is the recommended release flow in a nutshell for the release 24.7:
 
-[source,bash]
-----
+```shell
 # start with the product images ...
 # create and push the release branch
 ./release/create-release-branch.sh -b 24.7 -w products # Only add the -p flag after testing locally first
@@ -28,59 +27,50 @@ This is the recommended release flow in a nutshell for the release 24.7:
 
 # and that is it!
 # (now the tedious post release steps start ...)
-----
+```
 
 ## Release scripts
 
 A set of scripts that automates some release steps. The release process has multiple steps:
 
 1. Call `create-release-branch.sh`- This will:
-
-- create a temporary folder
-- clone operator and image repositories
-- create a new release branch for each repository
-
+  - create a temporary folder
+  - clone operator and image repositories
+  - create a new release branch for each repository
 2. Test and fix things in the release branches
-
-- changes should be done by making changes in the main branch and then cherry-picking these changes back into the release branch
-
+  - changes should be done by making changes in the main branch and then cherry-picking these changes back into the release branch
 3. Call `create-release-tag.sh`- This will:
-
-- checks that the appropriate release branch exists
-- switch to the previously-created release branch in each repository
-- conduct code refactoring
-- commit and tag these changes
-- push the resulting commits and tags, triggering github actions to build the product images and operators
-
+  - checks that the appropriate release branch exists
+  - switch to the previously-created release branch in each repository
+  - conduct code refactoring
+  - commit and tag these changes
+  - push the resulting commits and tags, triggering github actions to build the product images and operators
 4. Call `post-release.sh`- This will:
+  - update the operator CHANGELOG.md in `main` with changes from the release tag
+  - create PRs for all operators
 
-- update the operator CHANGELOG.md in `main` with changes from the release tag
-- create PRs for all operators
-
-image::images/rb-utils.png[]
+![](./images/rb-utils.png)
 
 ### Install requirements
 
 #### cargo-edit plugin
 
-
 The `cargo-edit` plugin is used to update operator versions in `cargo` workspaces.
 
 Install it like this:
 
-[source,bash]
-----
+```shell
 cargo install cargo-edit --version 0.12.3
-----
+```
 
 #### yq (yaml parser)
 
-This script requires https://github.com/mikefarah/yq (not to be confused with https://github.com/kislyuk/yq).
+This script requires <https://github.com/mikefarah/yq> (not to be confused with <https://github.com/kislyuk/yq>).
 
 #### gh (github client)
 
-This script requires https://github.com/cli to be installed.
-You have to be logged in when running the `post-release.sh` script. The easiest way is to have a local env variable `GH_TOKEN` set to a classic token created via https://github.com/settings/tokens with all `repo` and all `admin:org` scopes or follow the login instructions here https://cli.github.com/manual/gh_auth_login.
+This script requires <https://github.com/cli> to be installed.
+You have to be logged in when running the `post-release.sh` script. The easiest way is to have a local env variable `GH_TOKEN` set to a classic token created via <https://github.com/settings/tokens> with all `repo` and all `admin:org` scopes or follow the login instructions here <https://cli.github.com/manual/gh_auth_login>.
 
 ### Usage
 
@@ -88,10 +78,9 @@ You have to be logged in when running the `post-release.sh` script. The easiest 
 
 To create release branches use the `create-release-branch.sh` script, called from the repository root folder. The syntax is given below:
 
-[source]
-----
+```
 ./release/create-release-branch.sh -b <release> [-p] [-c] [-w products|operators|both]
-----
+```
 
 - `-b <release>`: the release number (mandatory). This must be a semver-compatible value (i.e. without leading zeros) such as `23.1`, `23.10` etc. and will be used to create a branch with the name `release-<release>` e.g. `release-23.1`
 - `-p`: push flag (optional, default is "false"). If provided, the created branches plus any changes made as part of this process will be pushed to the origin.
@@ -102,36 +91,33 @@ N.B. the flags cannot be combined (e.g. `-p -c` but not `-pc)
 
 e.g.
 
-[source]
-----
+```shell
 ./release/create-release-branch.sh -b 23.1 -p -c -w both
-----
+```
 
 ##### What this script does
 
-* checks that the release argument is valid (e.g. semver-compatible, just major/minor levels)
-* strips this argument of any leading or trailing quote marks
-* for docker images
-** creates or updates a temporary folder with clones of the images repository (given in `config.yaml`)
-** creates the new branch according to the release version
-** pushes the new branch (if requested with "-p")
-** deletes the temporary folder (if requested with "-c")
-* for operators:
-** iterates over a list of operator repository names (listed in `config.yaml`), and for each one:
-** clones or updates operator and product images repositories
-** creates the new branch according to the release version
-** pushes the new branch (if requested with "-p")
-** deletes the temporary folder (if requested with "-c")
-
+- checks that the release argument is valid (e.g. semver-compatible, just major/minor levels)
+- strips this argument of any leading or trailing quote marks
+- for docker images
+  - creates or updates a temporary folder with clones of the images repository (given in `config.yaml`)
+  - creates the new branch according to the release version
+  - pushes the new branch (if requested with "-p")
+  - deletes the temporary folder (if requested with "-c")
+- for operators:
+  - iterates over a list of operator repository names (listed in `config.yaml`), and for each one:
+  - clones or updates operator and product images repositories
+  - creates the new branch according to the release version
+  - pushes the new branch (if requested with "-p")
+  - deletes the temporary folder (if requested with "-c")
 
 #### Release tags
 
 To create release tags use the `create-release-tag.sh` script, called from the repository root folder. The syntax is given below:
 
-[source]
-----
+```
 ./release/create-release-tag.sh -t <release-tag> [-p] [-c] [-w products|operators|both]
-----
+```
 
 - `-t <release-tag>`: the release tag (mandatory). This must be a semver-compatible value (i.e. major/minor/path, without leading zeros) such as `23.1.0`, `23.10.3` etc. and will be used to create a tag with the name
 - `-p`: push flag (optional, default is "false"). If provided, the created commits and tags made as part of this process will be pushed to the origin.
@@ -142,47 +128,44 @@ N.B. the flags cannot be combined (e.g. `-p -c` but not `-pc)
 
 e.g.
 
-[source]
-----
+```shell
 ./release/create-release-tag.sh -t 23.1.0 -p -c -w both
-----
+```
 
 ##### What this script does
 
-* checks that the release argument is valid (e.g. semver-compatible, major/minor/patch levels)
-* for docker images:
-
-** tags the branch and pushes it if the push argument is provided
-* for operators:
-** checks that the release branch exists and the tag doesn't
-** adapts the versions in all cargo.toml to `release-tag` argument
-** update all "operatorVersion" fields in the tests/release.yaml files
-** update the antora.yaml
-** update the  `release-tag` in helm charts
-** updates the cargo workspace
-** rebuilds the helm charts
-** bumps the changelog
-** creates a tagged commit in the branch (i.e. the changes are valid for the branch lifetime)
-** pushes the commit and tag (if requested with "-p")
-** deletes the temporary folder (if requested with "-c")
+- checks that the release argument is valid (e.g. semver-compatible, major/minor/patch levels)
+- for docker images:
+  - tags the branch and pushes it if the push argument is provided
+- for operators:
+  - checks that the release branch exists and the tag doesn't
+  - adapts the versions in all cargo.toml to `release-tag` argument
+  - update all "operatorVersion" fields in the tests/release.yaml files
+  - update the antora.yaml
+  - update the  `release-tag` in helm charts
+  - updates the cargo workspace
+  - rebuilds the helm charts
+  - bumps the changelog
+  - creates a tagged commit in the branch (i.e. the changes are valid for the branch lifetime)
+  - pushes the commit and tag (if requested with "-p")
+  - deletes the temporary folder (if requested with "-c")
 
 #### Post-release steps
 
 Some post release steps are performed with `release/post-release.sh` script, called from the repository root folder. The syntax is given below:
 
-[source]
-----
+```
 ./release/post-release.sh -t <release-tag> [-p]
-----
+```
 
 - `-t <release-tag>`: the release tag (mandatory). This must be a semver-compatible value (i.e. major/minor/path, without leading zeros) such as `23.1.0`, `23.10.3` etc. and will be used to create a tag with the name
 - `-p`: push flag (optional, default is "false"). If provided, the created commits and tags made as part of this process will be pushed to the origin.
 
 ##### What this script does
 
-* checks that the release tag exists and that the all operator repositories have a clean working copy
-* merges the CHANGELOG.md from the release tag into main
-* creates PRs for all operators
+- checks that the release tag exists and that the all operator repositories have a clean working copy
+- merges the CHANGELOG.md from the release tag into main
+- creates PRs for all operators
 
 ##### Build actions
 
@@ -192,9 +175,7 @@ When a tag is pushed, the images for products and operators are built via github
 
 The build action script `release.yml` builds all product images that defined in the `release.yaml` matrix section:
 
-[source, yaml]
-----
-
+```yaml
 name: Release product images
 on:
   push:
@@ -212,7 +193,7 @@ jobs:
         - airflow
         - zookeeper
         ...
-----
+```
 
 Base images should be excluded from the build action as they need to be referenced by their manifest hashes in the product Dockerfiles and therefore should be built independently of the product images.
 
@@ -222,15 +203,14 @@ Also note that the tag pattern above is not using a regex (this functionality is
 
 Operator images are built by iterating over and pushing tags for the operator-repositories listed in the `operators` section of `config.yaml`:
 
-[source, yaml]
-----
+```yaml
 images-repo: docker-images
   operators:
     - airflow
     - secret
     - commons
     - ...
-----
+```
 
 #### Post-release steps
 
@@ -240,10 +220,9 @@ Once the release is complete and all steps above have been verified, the documen
 
 To create release tags for bugfix/patch releases use the `create-bugfix-tag.sh` script, called from the repository root folder. The syntax is given below:
 
-[source]
-----
+```
 ./release/create-bugfix-tag.sh -t <release-tag> [-p] [-c] [-w products|operators|both] [-i]
-----
+```
 
 - `-t <release-tag>`: the release tag (mandatory). This must be a semver-compatible value (i.e. major/minor/path, without leading zeros) such as `23.1.0`, `23.10.3` etc. and will be used to create a tag with the name
 - `-p`: push flag (optional, default is "false"). If provided, the created commits and tags made as part of this process will be pushed to the origin.
@@ -255,31 +234,30 @@ N.B. the flags cannot be combined (e.g. `-p -c` but not `-pc)
 
 e.g.
 
-[source]
-----
+```shell
 ./release/create-bugfix-tag.sh -t 23.1.0 -p -c -w both -i
-----
+```
 
 ##### What this script does
 
-* checks that the release argument is valid (e.g. semver-compatible, major/minor/patch levels)
-* strips this argument of any leading or trailing quote marks
-* for docker images
-** creates a temporary folder with clones of the images repository (given in `config.yaml`)
-** clones the docker images repository
-** checks that the release branch exists and the tag doesn't
-** switches to the release branch
-** tags the branch and pushes it if the push argument is provided
-** deletes the temporary folder (if requested with "-c")
-* for operators:
-** iterates over a list of operator repository names (listed in `config.yaml`), and for each one:
-** clones the operator repositories
-** checks that the release branch exists and the tag doesn't
-** switches to the release branch
-** updates crate versions and the workspace
-** updates test definitions to use product image versions that match the release tag (if requested with "-i")
-** tags the branch and pushes it if the push argument is provided
-** deletes the temporary folder (if requested with "-c")
+- checks that the release argument is valid (e.g. semver-compatible, major/minor/patch levels)
+- strips this argument of any leading or trailing quote marks
+- for docker images
+  - creates a temporary folder with clones of the images repository (given in `config.yaml`)
+  - clones the docker images repository
+  - checks that the release branch exists and the tag doesn't
+  - switches to the release branch
+  - tags the branch and pushes it if the push argument is provided
+  - deletes the temporary folder (if requested with "-c")
+- for operators:
+  - iterates over a list of operator repository names (listed in `config.yaml`), and for each one:
+  - clones the operator repositories
+  - checks that the release branch exists and the tag doesn't
+  - switches to the release branch
+  - updates crate versions and the workspace
+  - updates test definitions to use product image versions that match the release tag (if requested with "-i")
+  - tags the branch and pushes it if the push argument is provided
+  - deletes the temporary folder (if requested with "-c")
 
 ## Troubleshooting
 
@@ -295,4 +273,4 @@ You can adapt the `/tmp` folder in  `TEMP_RELEASE_FOLDER` in the `create-release
 
 #### missing libraries
 
-When building the secret-operator some libraries may be missing. See https://docs.stackable.tech/home/stable/secret-operator/building#_local_builds[secret-operator local builds] for requirements):
+When building the secret-operator some libraries may be missing. See: [secret-operator local builds](https://docs.stackable.tech/home/stable/secret-operator/building#_local_builds) for requirements.

--- a/release/README.md
+++ b/release/README.md
@@ -53,6 +53,11 @@ A set of scripts that automates some release steps. The release process has mult
 
 ### Install requirements
 
+> [!NOTE]
+> Nix users will not need to install anything, just enter the `nix-shell` in this repository (if not done automatically via `direnv`). 
+> The dependencies will install automatically.
+> A nix-shell will be entered for each operator during certain commands, so operator dependencies will be covered too.
+
 #### cargo-edit plugin
 
 The `cargo-edit` plugin is used to update operator versions in `cargo` workspaces.

--- a/release/create-bugfix-tag.sh
+++ b/release/create-bugfix-tag.sh
@@ -33,8 +33,10 @@ tag_operators() {
     cargo set-version --offline --workspace "$RELEASE_TAG"
 
     cargo update --workspace
-    make regenerate-charts
-    make regenerate-nix
+    # Run via nix-shell for the correct dependencies. Makefile already calls
+    # nix stuff, so it shouldn't be a problem for non-nix users.
+    nix-shell --run 'make regenerate-charts'
+    nix-shell --run 'make regenerate-nix'
 
     update_code "$TEMP_RELEASE_FOLDER/${operator}"
     #-----------------------------------------------------------

--- a/release/create-bugfix-tag.sh
+++ b/release/create-bugfix-tag.sh
@@ -14,7 +14,7 @@ REPOSITORY="origin"
 tag_products() {
   cd "$TEMP_RELEASE_FOLDER/$DOCKER_IMAGES_REPO"
   git switch "$RELEASE_BRANCH"
-  git tag "$RELEASE_TAG"
+  git tag -sm "release $RELEASE_TAG" "$RELEASE_TAG"
   push_branch
 }
 
@@ -41,8 +41,8 @@ tag_operators() {
     #-----------------------------------------------------------
     "$TEMP_RELEASE_FOLDER/${operator}"/scripts/docs_templating.sh
 
-    git commit -am "release $RELEASE_TAG"    
-    git tag "$RELEASE_TAG"
+    git commit -sam "release $RELEASE_TAG"    
+    git tag -sm "release $RELEASE_TAG" "$RELEASE_TAG"
     push_branch
   done < <(yq '... comments="" | .operators[] ' "$INITIAL_DIR"/release/config.yaml)
 }

--- a/release/create-bugfix-tag.sh
+++ b/release/create-bugfix-tag.sh
@@ -34,6 +34,7 @@ tag_operators() {
 
     cargo update --workspace
     make regenerate-charts
+    make regenerate-nix
 
     update_code "$TEMP_RELEASE_FOLDER/${operator}"
     #-----------------------------------------------------------

--- a/release/create-release-tag.sh
+++ b/release/create-release-tag.sh
@@ -20,8 +20,8 @@ tag_products() {
 	git switch "$RELEASE_BRANCH"
 	update_product_images_changelogs
 
-	git commit -am "release $RELEASE_TAG"
-	git tag "$RELEASE_TAG" -m "release $RELEASE_TAG"
+	git commit -sam "release $RELEASE_TAG"
+	git tag -sm "release $RELEASE_TAG" "$RELEASE_TAG"
 	push_branch
 }
 
@@ -50,8 +50,8 @@ tag_operators() {
 		#-----------------------------------------------------------
 		update_changelog "$TEMP_RELEASE_FOLDER/${operator}"
 
-		git commit -am "release $RELEASE_TAG"
-		git tag "$RELEASE_TAG" -m "release $RELEASE_TAG"
+		git commit -sam "release $RELEASE_TAG"
+		git tag -sm "release $RELEASE_TAG" "$RELEASE_TAG"
 		push_branch
 	done < <(yq '... comments="" | .operators[] ' "$INITIAL_DIR"/release/config.yaml)
 }

--- a/release/create-release-tag.sh
+++ b/release/create-release-tag.sh
@@ -37,8 +37,10 @@ tag_operators() {
 
 		cargo set-version --offline --workspace "$RELEASE_TAG"
 		cargo update --workspace
-		make regenerate-charts
-		make regenerate-nix
+		# Run via nix-shell for the correct dependencies. Makefile already calls
+		# nix stuff, so it shouldn't be a problem for non-nix users.
+		nix-shell --run 'make regenerate-charts'
+		nix-shell --run 'make regenerate-nix'
 
 		update_code "$TEMP_RELEASE_FOLDER/${operator}"
 		#-----------------------------------------------------------

--- a/release/create-release-tag.sh
+++ b/release/create-release-tag.sh
@@ -38,6 +38,7 @@ tag_operators() {
 		cargo set-version --offline --workspace "$RELEASE_TAG"
 		cargo update --workspace
 		make regenerate-charts
+		make regenerate-nix
 
 		update_code "$TEMP_RELEASE_FOLDER/${operator}"
 		#-----------------------------------------------------------

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@
 pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
     cargo-edit
+    gh
     yq-go
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    cargo-edit
+    yq-go
+  ];
+}


### PR DESCRIPTION
- fix some typos
- fix heading levels
- enable syntax formatting
- replace the `-p` (push branches and tags) option with a comment for enabling it after testing
- explicitly sign commits and tags (per Stackable handbook)
- add `make regenerate-nix` so the Cargo.nix is updated with the release version
- run `make` commands in a nix-shell (per operator, to pickup necessary dependencies)
  - This should not affect anyone, as make already requires nix to be available.
- add a nix-shell with dependencies necessary to run the scripts
- convert asciidoc to markdown (to be consistent with the other READMEs)
- add links from main readme