### PR TITLE
update specified labels

### DIFF
--- a/release/create-release-tag.sh
+++ b/release/create-release-tag.sh
@@ -152,6 +152,10 @@ update_code() {
 	# Update operator version for the integration tests
 	# this is used when installing the operators.
 	yq -i ".releases.tests.products[].operatorVersion |= sub(\"0.0.0-dev\", \"${RELEASE_TAG}\")" "$1/tests/release.yaml"
+
+	# Some tests perform label inspection and for these cases only specific labels should be updated.
+	# N.B. don't do this for all test files as not all images will necessarily exist for the given release tag.
+	find "$1/tests/templates/kuttl" -type f -print0 | xargs -0 sed -i "/app.kubernetes.io\/version/{ s/stackable0.0.0-dev/stackable$RELEASE_TAG/ }"
 }
 
 push_branch() {


### PR DESCRIPTION
Some (at the moment, just one, for Kaka) tests run asserts against labels that are release-tag-specific. This PR includes that in the tag script. See https://github.com/stackabletech/kafka-operator/pull/737 for context.

Tested by running a dry-run release for 24.11.0 locally for all operators and checking that only relevant lines were changed (currently, only for the kafka test):
`app.kubernetes.io/version: "{{ test_scenario['values']['upgrade_new'] }}-stackable24.11.0"`
