### PR TITLE
olm manifest cleanups

### DIFF
--- a/olm/build-manifests.py
+++ b/olm/build-manifests.py
@@ -485,19 +485,6 @@ def generate_helm_templates(args: argparse.Namespace) -> list[dict]:
             except KeyError:
                 pass
 
-            ### Patch the product cluster role with the SCC rule
-            if (
-                man["kind"] == "ClusterRole"
-                and man["metadata"]["name"] == f"{args.product}-clusterrole"
-            ):
-                man["rules"].append(
-                    {
-                        "apiGroups": ["security.openshift.io"],
-                        "resources": ["securitycontextconstraints"],
-                        "resourceNames": ["nonroot-v2"],
-                        "verbs": ["use"],
-                    }
-                )
             ### Patch the version label
             try:
                 if (

--- a/olm/build-manifests.sh
+++ b/olm/build-manifests.sh
@@ -60,19 +60,6 @@ annotations:
   com.redhat.openshift.versions: v4.12-v4.15
 ANNOS
 
-  cat >dependencies.yaml <<-DEPS
----
-dependencies:
-  - type: olm.package
-    value:
-      packageName: stackable-commons-operator
-      version: "$RELEASE_VERSION"
-  - type: olm.package
-    value:
-      packageName: stackable-secret-operator
-      version: "$RELEASE_VERSION"
-DEPS
-
   popd
 }
 


### PR DESCRIPTION
- **fix(build-manifests): do not override the scc anymore**
- **do not generate dependency manifests anymore**
