### PR TITLE
fix: updates for olm 24.11.1

### DIFF
--- a/olm/build-manifests.py
+++ b/olm/build-manifests.py
@@ -565,11 +565,17 @@ def quay_image(images: list[tuple[str, str]]) -> list[dict[str, str]]:
                 )
 
             manifest_digest = [
-                t["manifest_digest"] for t in data["tags"] if t["name"] == release
-            ][0]
+                t["manifest_digest"] for t in data["tags"] if t["name"] == release and t["is_manifest_list"] == True
+            ]
+
+            if len(manifest_digest) == 0:
+                raise ManifestException(f"No manifest list for {image}:{release} found")
+
+            if len(manifest_digest) > 1:
+                raise ManifestException(f"Multiple manifest lists for {image}:{release} found but only one expected")
 
             result.append(
-                {"name": image, "image": f"quay.io/stackable/{image}@{manifest_digest}"}
+                {"name": image, "image": f"quay.io/stackable/{image}@{manifest_digest[0]}"}
             )
     logging.debug("finish op_image")
     return result

--- a/olm/resources/csv.yaml
+++ b/olm/resources/csv.yaml
@@ -25,7 +25,6 @@ metadata:
         description: Stackable Operator for placeholder
         repository: https://github.com/stackabletech/placeholder
         containerImage: placeholder
-        olm.skipRange: placeholder
 spec:
     displayName: placeholder
     description: |


### PR DESCRIPTION
Changes to the OLM manifest scaffolding tool:

* Ensure that image **manifests** (not arch specific) from quay.io are referenced in the CSVs.
* Remove the CSVs `olm.skipRange` annotation as it breaks the certification pipeline.