### PR TITLE
fix(release): Make scripts exit on failure

### DIFF
--- a/release/create-release-candidate-branch.sh
+++ b/release/create-release-candidate-branch.sh
@@ -71,8 +71,7 @@ check_tag_is_valid() {
 	git fetch --tags
 
 	# check tags: N.B. look for exact match
-	TAG_EXISTS=$(git tag --list | grep -E "$RELEASE_TAG$")
-	if [ -n "$TAG_EXISTS" ]; then
+	if git tag --list | grep -E "^$RELEASE_TAG\$"; then
 		>&2 echo "Tag $RELEASE_TAG already exists!"
 		exit 1
 	fi
@@ -100,17 +99,18 @@ check_products() {
 
 	# switch to the release branch, which should exist as tagging
 	# is subsequent to creating the branch.
-	BRANCH_EXISTS=$(git branch -a | grep -E "$RELEASE_BRANCH$")
-
-	if [ -z "${BRANCH_EXISTS}" ]; then
+	# Note, if this needs to check the branch exists locally, then use:
+	# "^[ *]*$RELEASE_BRANCH\$"
+	if ! git branch -a | grep -E "$RELEASE_BRANCH\$"; then
 		>&2 echo "Expected release branch is missing: $RELEASE_BRANCH"
 		exit 1
 	fi
 
 	# the new PR should not exist, otherwise a duplicate commit
 	# will be prepared
-	BRANCH_EXISTS=$(git branch -a | grep -E "$PR_BRANCH$")
-	if [ -n "${BRANCH_EXISTS}" ]; then
+	# Note, if this needs to check the branch exists locally, then use:
+	# "^[ *]*$PR_BRANCH\$"
+	if git branch -a | grep -E "$PR_BRANCH\$"; then
 		>&2 echo "PR branch already exists: ${REMOTE}/$PR_BRANCH"
 		exit 1
 	fi
@@ -137,16 +137,18 @@ check_operators() {
 
 		fi
 		cd "$TEMP_RELEASE_FOLDER/${operator}"
-		BRANCH_EXISTS=$(git branch -a | grep -E "$RELEASE_BRANCH$")
-		if [ -z "${BRANCH_EXISTS}" ]; then
+		# Note, if this needs to check the branch exists locally, then use:
+		# "^[ *]*$RELEASE_BRANCH\$"
+		if ! git branch -a | grep -E "$RELEASE_BRANCH\$"; then
 			>&2 echo "Expected release branch is missing: ${operator}/$RELEASE_BRANCH"
 			exit 1
 		fi
 
 		# the new PR should not exist, otherwise a duplicate commit
 		# will be prepared
-		BRANCH_EXISTS=$(git branch -a | grep -E "$PR_BRANCH$")
-		if [ -n "${BRANCH_EXISTS}" ]; then
+		# Note, if this needs to check the branch exists locally, then use:
+		# "^[ *]*$PR_BRANCH\$"
+		if git branch -a | grep -E "$PR_BRANCH\$"; then
 			>&2 echo "PR branch already exists: ${operator}/$PR_BRANCH"
 			exit 1
 		fi
@@ -292,14 +294,12 @@ parse_inputs() {
 
 check_dependencies() {
 	# check for a globally configured git user
-	git_user=$(git config --global --includes --get user.name)
-	git_email=$(git config --global --includes --get user.email)
-	echo "global git user: $git_user <$git_email>"
-
-	if [ -z "$git_user" ] || [ -z "$git_email" ]; then
+	if ! git_user=$(git config --global --includes --get user.name) \
+	|| ! git_email=$(git config --global --includes --get user.email); then
 		>&2 echo "Error: global git user name/email is not set."
 		exit 1
 	else
+		echo "global git user: $git_user <$git_email>"
 		echo "Is this correct? (y/n)"
 		read -r response
 		if [[ "$response" == "y" || "$response" == "Y" ]]; then

--- a/release/create-release-candidate-branch.sh
+++ b/release/create-release-candidate-branch.sh
@@ -344,10 +344,7 @@ main() {
 	check_dependencies
 
 	# sanity checks before we start: folder, branches etc.
-	# deactivate -e so that piped commands can be used
-	set +e
 	checks
-	set -e
 
 	echo "Cloning docker-images and/or operators to [$TEMP_RELEASE_FOLDER]"
 	rc_branch_repos

--- a/release/merge-release-candidate.sh
+++ b/release/merge-release-candidate.sh
@@ -89,14 +89,12 @@ merge() {
 
 check_dependencies() {
 	# check for a globally configured git user
-	git_user=$(git config --global --includes --get user.name)
-	git_email=$(git config --global --includes --get user.email)
-	echo "global git user: $git_user <$git_email>"
-
-	if [ -z "$git_user" ] || [ -z "$git_email" ]; then
+	if ! git_user=$(git config --global --includes --get user.name) \
+	|| ! git_email=$(git config --global --includes --get user.email); then
 		>&2 echo "Error: global git user name/email is not set."
 		exit 1
 	else
+		echo "global git user: $git_user <$git_email>"
 		echo "Is this correct? (y/n)"
 		read -r response
 		if [[ "$response" == "y" || "$response" == "Y" ]]; then

--- a/release/post-release.sh
+++ b/release/post-release.sh
@@ -199,20 +199,14 @@ main() {
 
   if [ "products" == "$WHAT" ] || [ "all" == "$WHAT" ]; then
     # sanity checks before we start: folder, branches etc.
-    # deactivate -e so that piped commands can be used
-    set +e
     check_products
-    set -e
 
     echo "Update $DOCKER_IMAGES_REPO main changelog for release $RELEASE_TAG"
     update_products
   fi
   if [ "operators" == "$WHAT" ] || [ "all" == "$WHAT" ]; then
     # sanity checks before we start: folder, branches etc.
-    # deactivate -e so that piped commands can be used
-    set +e
     check_operators
-    set -e
 
     echo "Update the operator main changelog for release $RELEASE_TAG"
     update_operators

--- a/release/post-release.sh
+++ b/release/post-release.sh
@@ -64,14 +64,14 @@ check_operators() {
       exit 2
     fi
 
-    BRANCH_EXISTS=$(git branch -a | grep "$RELEASE_BRANCH")
-    if [ -z "$BRANCH_EXISTS" ]; then
+    # Note, if this needs to check the branch exists locally, then use:
+    # "^[ *]*$RELEASE_BRANCH\$"
+    if ! git branch -a | grep "$RELEASE_BRANCH\$"; then
       >&2 echo "Expected release branch is missing: $OPERATOR/$RELEASE_BRANCH"
       exit 1
     fi
     git fetch --tags
-    TAG_EXISTS=$(git tag | grep "$RELEASE_TAG")
-    if [ -z "$TAG_EXISTS" ]; then
+    if ! git tag | grep "^$RELEASE_TAG\$"; then
       >&2 echo "Expected tag $RELEASE_TAG missing for operator $OPERATOR"
       exit 1
     fi
@@ -127,15 +127,16 @@ check_products() {
     exit 2
   fi
 
-  BRANCH_EXISTS=$(git branch -a | grep "$RELEASE_BRANCH")
-  if [ -z "${BRANCH_EXISTS}" ]; then
+  # Note, if this needs to check the branch exists locally, then use:
+  # "^[ *]*$RELEASE_BRANCH\$"
+  if ! git branch -a | grep "$RELEASE_BRANCH\$"; then
     >&2 echo "Expected release branch is missing: $DOCKER_IMAGES_REPO/$RELEASE_BRANCH"
     exit 1
   fi
 
   git fetch --tags
-  TAG_EXISTS=$(git tag | grep "$RELEASE_TAG")
-  if [ -z "${TAG_EXISTS}" ]; then
+  # check tags: N.B. look for exact match
+  if ! git tag | grep "^$RELEASE_TAG\$"; then
     >&2 echo "Expected tag $RELEASE_TAG missing for $DOCKER_IMAGES_REPO"
     exit 1
   fi

--- a/release/tag-release-candidate.sh
+++ b/release/tag-release-candidate.sh
@@ -210,10 +210,7 @@ main() {
 	check_dependencies
 
 	# sanity checks before we start: folder, branches etc.
-	# deactivate -e so that piped commands can be used
-	set +e
 	checks
-	set -e
 
 	tag_repos
 	cleanup

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,6 @@
-{ pkgs ? import <nixpkgs> { } }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
     cargo-edit
@@ -7,5 +9,6 @@ pkgs.mkShell {
     jinja2-cli
     yq-go
     python311Packages.pip
+    python311Packages.pyyaml
   ];
 }


### PR DESCRIPTION
Fixes https://github.com/stackabletech/stackable-utils/issues/103

If they were originally there to handle failures without exiting then that should be done through regular means without disabling the flag.