### PR TITLE
fix: Update git state before doing important things

### DIFF
--- a/release/EXAMPLE_PROCESS.md
+++ b/release/EXAMPLE_PROCESS.md
@@ -1,0 +1,184 @@
+# Release script process
+
+## Dry run testing
+
+It is a good idea to do a dry-run check locally, and then delete the local state.
+
+```sh
+# Clone to /tmp/stackable-release-YY.M/docker-images and/or enter the directory.
+# Create and switch to branch: release-YY.M.
+./release/create-release-branch.sh -b YY.M -w products
+./release/create-release-branch.sh -b YY.M -w operators
+./release/create-release-branch.sh -b YY.M -w demos
+
+# Clone to /tmp/stackable-release-YY.M/docker-images and/or enter the directory.
+# Fetch and switch to branch: release-YY.M.
+#   NOTE: this would only work for dry run if the previous step was done on the
+#         same machine and not deleted. Else the release branch won't be found.
+# Create and switch to branch: pr-YY.M.X-rc1.
+# Update the change log, and commit it (skip pushing).
+# Raise a PR (dry-run).
+./release/create-release-candidate-branch.sh -t YY.M.X-rc1 -w products
+./release/create-release-candidate-branch.sh -t YY.M.X-rc1 -w operators
+
+# Pretend the PR exists, and exit.
+# This doesn't really test much.
+./release/merge-release-candidate.sh -t YY.M.X-rc1 -w products
+./release/merge-release-candidate.sh -t YY.M.X-rc1 -w operators
+
+# Clone to /tmp/stackable-release-YY.M/docker-images and/or enter the directory.
+# Fetch and switch to branch: release-YY.M.
+#   NOTE: this would only work for dry run if the first step was done on the
+#         same machine and not deleted. Else the release branch won't be found.
+# Tag the HEAD commit (in this case it would be the same as `main` where this branch was based).
+./release/tag-release-candidate.sh -t YY.M.X-rc1 -w products
+./release/tag-release-candidate.sh -t YY.M.X-rc1 -w operators
+
+# TODO: ./release/post-release.sh
+```
+
+Finally, delete the dirty state:
+
+```sh
+rm -fr /tmp/stackable-release-YY.M
+```
+
+## Actual release
+
+### Release Candidates
+
+This procedure would be done until a viable release-candidate can be selected.
+
+```sh
+# Clone to /tmp/stackable-release-YY.M/docker-images and/or enter the directory.
+# Create and switch to branch: release-YY.M.
+# Push the branch.
+./release/create-release-branch.sh -b YY.M -w products -p
+./release/create-release-branch.sh -b YY.M -w operators -p
+./release/create-release-branch.sh -b YY.M -w demos -p
+
+# Clone to /tmp/stackable-release-YY.M/docker-images and/or enter the directory.
+# Fetch and switch to branch: release-YY.M.
+# Create and switch to branch: pr-YY.M.X-rc1.
+# Update the change log, and commit it.
+# Push the branch.
+# Raise a PR.
+./release/create-release-candidate-branch.sh -t YY.M.X-rc1 -w products -p
+./release/create-release-candidate-branch.sh -t YY.M.X-rc1 -w operators -p
+```
+
+Ask people to do approvals.
+
+> [!TIP]
+> It is nice to drop all the links in a Slack message to make it easier.
+> You can search the output for `https://github.com/stackabletech/.*/pull/[0-9]+`
+
+Once all approvals are done, merge the changes and tag the release branch `HEAD`.
+
+```sh
+# Check that PRs are `OPEN`.
+# Merge the PR (this does not seem to wait for checks to complete).
+./release/merge-release-candidate.sh -t YY.M.X-rc1 -w products -p
+./release/merge-release-candidate.sh -t YY.M.X-rc1 -w operators -p
+```
+
+It is still worth checking that all PRs are merged.
+
+```sh
+# Clone to /tmp/stackable-release-YY.M/docker-images and/or enter the directory.
+# Fetch, including tags.
+# Ensure tag does not already exist.
+# Switch to the release branch.
+# Pull.
+# Tag HEAD.
+# Push tag.
+./release/tag-release-candidate.sh -t YY.M.X-rc1 -w products -p
+./release/tag-release-candidate.sh -t YY.M.X-rc1 -w operators -p
+```
+
+> [!CAUTION]
+> Wait for images to be built.
+>
+> To ensure all image artifacts have been pushed, see [image-checks.sh](./image-checks.sh).
+
+Now do release candidate Testing.
+
+Repeat this process if this release-candidate is not viable (changing `rc1` to `rc2` for example).
+
+### Promote RC to Release
+
+Once the release candidate has been deemed good, do the release proper:
+
+> [!NOTE]
+> `create-release-candidate-branch` is a misnomer, since it is a release branch.
+> But this step is necessary to update the version numbers throughout the repository
+> to the final version number for the release.
+
+```sh
+# Clone to /tmp/stackable-release-YY.M/docker-images and/or enter the directory.
+# Fetch and switch to branch: release-YY.M.
+# Create and switch to branch: pr-YY.M.X.
+# Update the change log, and commit it.
+# Push the branch.
+# Raise a PR.
+./release/create-release-candidate-branch.sh -t YY.M.X -w products -p
+./release/create-release-candidate-branch.sh -t YY.M.X -w operators -p
+```
+
+Ask people to do approvals.
+
+> [!TIP]
+> It is nice to drop all the links in a Slack message to make it easier.
+> You can search the output for `https://github.com/stackabletech/.*/pull/[0-9]+`
+
+Once all approvals are done, merge the changes and tag the release branch `HEAD`.
+
+```sh
+# Check that PRs are `OPEN`.
+# Merge the PR (this does not seem to wait for checks to complete).
+./release/merge-release-candidate.sh -t YY.M.X -w products -p
+./release/merge-release-candidate.sh -t YY.M.X -w operators -p
+
+# Clone to /tmp/stackable-release-YY.M/docker-images and/or enter the directory.
+# Fetch, including tags.
+# Ensure tag does not already exist.
+# Switch to the release branch.
+# Pull.
+# Tag HEAD.
+# Push tag.
+./release/tag-release-candidate.sh -t YY.M.X -w products -p
+./release/tag-release-candidate.sh -t YY.M.X -w operators -p
+```
+
+> [!CAUTION]
+> Wait for images to be built.
+>
+> To ensure all image artifacts have been pushed, see [image-checks.sh](./image-checks.sh).
+
+Once everything is looking good, the release can be mentioned in the `main` branch.
+
+```sh
+# Clone to /tmp/stackable-release-YY.M/docker-images and/or enter the directory.
+# Fetch, including tags.
+# Ensure the release tag exists.
+# Checkout the main branch.
+# Pull.
+# Create and switch to branch: chore/update-changelog-from-release-YY.M.X.
+# Checkout the CHANGELOG.md at tag YY.M.X.
+# Ensure only the CHANGELOG.md has changed.
+#   NOTE: It could be possible that new changes have gone into `main`.
+#         These will need to be fixed on the branch (they should be obvious when
+#         reviewing the PR).
+# Add and commit the CHANGELOG.md from the release.
+# Push the branch.
+# Raise a PR.
+./release/post-release.sh -t YY.M.X -p
+```
+
+Ask people to do approvals.
+
+> [!TIP]
+> It is nice to drop all the links in a Slack message to make it easier.
+> You can search the output for `https://github.com/stackabletech/.*/pull/[0-9]+`
+
+Once all approvals are done, manually merge the PRs.

--- a/release/README.md
+++ b/release/README.md
@@ -1,6 +1,9 @@
 # Release workflow
 
-This is the recommended release flow in a nutshell for the release 25.3.
+> [!TIP]
+> If you are performing a release, you might want to skip over to [EXAMPLE_PROCESS](./EXAMPLE_PROCESS.md) which illustrates the process start to finish.
+
+This is the recommended release flow in a nutshell for the release 25.7.
 These steps are repeated for each release tag i.e. for both release-candidates and non-release-candidates:
 
 ```shell

--- a/release/create-release-candidate-branch.sh
+++ b/release/create-release-candidate-branch.sh
@@ -97,6 +97,10 @@ check_products() {
 	fi
 	cd "$TEMP_RELEASE_FOLDER/$DOCKER_IMAGES_REPO"
 
+	# Need to update here because if we deleted the local state, or someone else continues
+    # we might be back on main, or on the release branch without having pulled updates from fixes.
+	git fetch && git switch "$RELEASE_BRANCH" && git pull
+
 	# switch to the release branch, which should exist as tagging
 	# is subsequent to creating the branch.
 	# Note, if this needs to check the branch exists locally, then use:
@@ -133,6 +137,10 @@ check_operators() {
 
 		fi
 		cd "$TEMP_RELEASE_FOLDER/${operator}"
+
+		# Need to update here because if we deleted the local state, or someone else continues
+		# we might be back on main, or on the release branch without having pulled updates from fixes.
+		git fetch && git switch "$RELEASE_BRANCH" && git pull
 		# Note, if this needs to check the branch exists locally, then use:
 		# "^[ *]*$RELEASE_BRANCH\$"
 		if ! git branch -a | grep -E "$RELEASE_BRANCH\$"; then

--- a/release/image-checks.sh
+++ b/release/image-checks.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+# Usage:
+# 1. Update the product and SDP versions at the end of the scripts
+# 2. ./release/image-checks.sh
+# 3. Check for missing artifacts in the output (it should be an obvious change in the pattern)
+#
+# It could be improved in future to assert things exist, and provide a clear error message when they don't.
+
+# This is a handy utility for checking the existance of images.
+# It does currently reqiure manually choosing product versions to check,
+# but this list could be automated through conf.py
+read -p "Be sure to update the versions in this script before running. Press Enter to continue"
+
+# prepend a string to each line of stdout
+# Usage:
+#   echo "patch written to: $PATCH" | prepend "\t"
+function prepend {
+  while read -r line; do
+    echo -e "${1}${line}"
+  done
+}
+
+if [ -z "$HARBOR_TOKEN" ]; then
+  read -s -p "Harbor Token (find it in the web UI): " HARBOR_TOKEN
+fi
+
+HARBOR_AUTH_HEADER="Authorization: Bearer $HARBOR_TOKEN"
+TAGS_JQ_QUERY='.tags[] | select(. == $tag)'
+
+# Check that per-arch images and a manifests exist for an operator.
+# Usage:
+#   check_tags_for_operator airflow-operator 25.7.0
+#   check_tags_for_operator airflow-operator 25.7.0 sandbox
+check_tags_for_operator() {
+    local operator="$1"
+    local sdp_version="$2"
+    local project="${3:-sdp}"
+
+    echo "Checking $operator for SDP $sdp_version"
+    local tags_url="https://oci.stackable.tech/v2/$project/$operator/tags/list"
+
+    curl -sSL -H "$HARBOR_AUTH_HEADER" "$tags_url" | jq -re "$TAGS_JQ_QUERY" --arg tag "$sdp_version-arm64" | prepend "\t"
+    curl -sSL -H "$HARBOR_AUTH_HEADER" "$tags_url" | jq -re "$TAGS_JQ_QUERY" --arg tag "$sdp_version-amd64" | prepend "\t"
+    curl -sSL -H "$HARBOR_AUTH_HEADER" "$tags_url" | jq -re "$TAGS_JQ_QUERY" --arg tag "$sdp_version" | prepend "\t"
+}
+
+
+# this could use some work to handle products under stackable instead of sdp
+# Check that per-arch images and a manifests exist for a product.
+# Usage:
+#   check_tags_for_product spark-k8s 3.5.6 25.7.0-rc1
+#   check_tags_for_product spark-connect-client 3.5.6 25.7.0 stackable
+check_tags_for_product() {
+    local product_name="$1"
+    local product_version="$2"
+    local sdp_version="$3"
+    local project="${4:-sdp}"
+
+    echo "Checking $project/$product_name@$product_version for SDP $sdp_version"
+    local tags_url="https://oci.stackable.tech/v2/$project/$product_name/tags/list"
+
+    curl -sSL -H "$HARBOR_AUTH_HEADER" "$tags_url" | jq -re "$TAGS_JQ_QUERY" --arg tag "$product_version-stackable$sdp_version-arm64" | prepend "\t"
+    curl -sSL -H "$HARBOR_AUTH_HEADER" "$tags_url" | jq -re "$TAGS_JQ_QUERY" --arg tag "$product_version-stackable$sdp_version-amd64" | prepend "\t"
+    curl -sSL -H "$HARBOR_AUTH_HEADER" "$tags_url" | jq -re "$TAGS_JQ_QUERY" --arg tag "$product_version-stackable$sdp_version" | prepend "\t"
+}
+
+# How it was run for the previous release:
+SDP_RELEASE=25.7.0
+check_tags_for_operator airflow-operator "$SDP_RELEASE"
+check_tags_for_operator commons-operator "$SDP_RELEASE"
+check_tags_for_operator druid-operator "$SDP_RELEASE"
+check_tags_for_operator hbase-operator "$SDP_RELEASE"
+check_tags_for_operator hdfs-operator "$SDP_RELEASE"
+check_tags_for_operator hive-operator "$SDP_RELEASE"
+check_tags_for_operator kafka-operator "$SDP_RELEASE"
+check_tags_for_operator listener-operator "$SDP_RELEASE"
+check_tags_for_operator nifi-operator "$SDP_RELEASE"
+check_tags_for_operator opa-operator "$SDP_RELEASE"
+check_tags_for_operator secret-operator "$SDP_RELEASE"
+check_tags_for_operator spark-k8s-operator "$SDP_RELEASE"
+check_tags_for_operator superset-operator "$SDP_RELEASE"
+check_tags_for_operator trino-operator "$SDP_RELEASE"
+check_tags_for_operator zookeeper-operator "$SDP_RELEASE"
+
+# Be sure to check the product versions for the release you a checking for.
+# This list was hand generated. It could be improved by evaluating conf.py.
+check_tags_for_product airflow 2.9.3 "$SDP_RELEASE"
+check_tags_for_product airflow 2.10.4 "$SDP_RELEASE"
+check_tags_for_product airflow 2.10.5 "$SDP_RELEASE"
+check_tags_for_product airflow 3.0.1 "$SDP_RELEASE"
+check_tags_for_product druid 30.0.1 "$SDP_RELEASE"
+check_tags_for_product druid 31.0.1 "$SDP_RELEASE"
+check_tags_for_product druid 33.0.0 "$SDP_RELEASE"
+check_tags_for_product hadoop 3.3.6 "$SDP_RELEASE"
+check_tags_for_product hadoop 3.4.1 "$SDP_RELEASE"
+check_tags_for_product hbase 2.6.1 "$SDP_RELEASE"
+check_tags_for_product hbase 2.6.2 "$SDP_RELEASE"
+check_tags_for_product hive 3.1.3 "$SDP_RELEASE"
+check_tags_for_product hive 4.0.0 "$SDP_RELEASE"
+check_tags_for_product hive 4.0.1 "$SDP_RELEASE"
+check_tags_for_product kafka-testing-tools 1.0.0 "$SDP_RELEASE"
+check_tags_for_product kafka 3.7.2 "$SDP_RELEASE"
+check_tags_for_product kafka 3.9.0 "$SDP_RELEASE"
+check_tags_for_product kafka 3.9.1 "$SDP_RELEASE"
+check_tags_for_product kafka 4.0.0 "$SDP_RELEASE"
+check_tags_for_product krb5 1.21.1 "$SDP_RELEASE"
+check_tags_for_product nifi 1.27.0 "$SDP_RELEASE"
+check_tags_for_product nifi 1.28.1 "$SDP_RELEASE"
+check_tags_for_product nifi 2.4.0 "$SDP_RELEASE"
+check_tags_for_product omid 1.1.2 "$SDP_RELEASE"
+check_tags_for_product omid 1.1.3 "$SDP_RELEASE"
+check_tags_for_product opa 1.4.2 "$SDP_RELEASE"
+check_tags_for_product opa 1.0.1 "$SDP_RELEASE"
+check_tags_for_product spark-connect-client 3.5.6 "$SDP_RELEASE" stackable
+check_tags_for_product spark-k8s 3.5.5 "$SDP_RELEASE"
+check_tags_for_product spark-k8s 3.5.6 "$SDP_RELEASE"
+check_tags_for_product superset 4.0.2 "$SDP_RELEASE"
+check_tags_for_product superset 4.1.1 "$SDP_RELEASE"
+check_tags_for_product superset 4.1.2 "$SDP_RELEASE"
+check_tags_for_product tools 1.0.0 "$SDP_RELEASE"
+check_tags_for_product trino 451 "$SDP_RELEASE"
+check_tags_for_product trino 470 "$SDP_RELEASE"
+check_tags_for_product trino 476 "$SDP_RELEASE"
+check_tags_for_product vector 0.47.0 "$SDP_RELEASE"
+check_tags_for_product zookeeper 3.9.3 "$SDP_RELEASE"

--- a/release/post-release.sh
+++ b/release/post-release.sh
@@ -84,10 +84,14 @@ update_operators() {
   while IFS="" read -r OPERATOR || [ -n "$OPERATOR" ]
   do
     cd "$TEMP_RELEASE_FOLDER/$OPERATOR"
+
+    git checkout main
+    git pull
+
     # New branch that updates the CHANGELOG
     CHANGELOG_BRANCH="chore/update-changelog-from-release-$RELEASE_TAG"
     # Branch out from main
-    git switch -c "$CHANGELOG_BRANCH" main
+    git switch -c "$CHANGELOG_BRANCH"
     # Checkout CHANGELOG changes from the release tag
     git checkout "$RELEASE_TAG" -- CHANGELOG.md
     # Ensure only the CHANGELOG has been modified and there
@@ -146,10 +150,14 @@ check_products() {
 # the changelog in the release branch.
 update_products() {
   cd "$TEMP_RELEASE_FOLDER/$DOCKER_IMAGES_REPO"
+
+  git checkout main
+  git pull
+
   # New branch that updates the CHANGELOG
   CHANGELOG_BRANCH="chore/update-changelog-from-release-$RELEASE_TAG"
   # Branch out from main
-  git switch -c "$CHANGELOG_BRANCH" main
+  git switch -c "$CHANGELOG_BRANCH"
   # Checkout CHANGELOG changes from the release tag
   git checkout "$RELEASE_TAG" -- CHANGELOG.md
   # Ensure only the CHANGELOG has been modified and there

--- a/release/tag-release-candidate.sh
+++ b/release/tag-release-candidate.sh
@@ -17,7 +17,13 @@ tag_products() {
 	cd "$TEMP_RELEASE_FOLDER/$DOCKER_IMAGES_REPO"
 
 	# the PR branch should already exist
-	git switch "$RELEASE_BRANCH" && git pull
+	git switch "$RELEASE_BRANCH"
+	if $PUSH; then
+		git pull
+	else
+		git pull || echo "Dry-run: remote branch doesn't exist yet..."
+		# NOTE (@NickLarsenNZ): We could add a fake commit, but that would poison the current state.
+	fi
 	git tag -sm "release $RELEASE_TAG" "$RELEASE_TAG"
 	push_branch
 }
@@ -25,7 +31,13 @@ tag_products() {
 tag_operators() {
 	while IFS="" read -r operator || [ -n "$operator" ]; do
 		cd "${TEMP_RELEASE_FOLDER}/${operator}"
-		git switch "$RELEASE_BRANCH" && git pull
+		git switch "$RELEASE_BRANCH"
+		if $PUSH; then
+			git pull
+		else
+			git pull || echo "Dry-run: remote branch doesn't exist yet..."
+			# NOTE (@NickLarsenNZ): We could add a fake commit, but that would poison the current state.
+		fi
 		git tag -sm "release $RELEASE_TAG" "$RELEASE_TAG"
 		push_branch
 	done < <(yq '... comments="" | .operators[] ' "$INITIAL_DIR"/release/config.yaml)


### PR DESCRIPTION
- Fix a script for dry-run mode
- Add docs with actual flow (maybe this should replace the flow in the main readme, but it is better than nothing IMO).
- Add a script to help check if images have been pushed

<details>
<summary>Example script output</summary>

```
❯ ./release/image-checks.sh                          
Be sure to update the versions in this script before running. Press Enter to continue
Harbor Token (find it in the web UI): Checking airflow-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking commons-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking druid-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking hbase-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking hdfs-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking hive-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking kafka-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking listener-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking nifi-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking opa-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking secret-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking spark-k8s-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking superset-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking trino-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking zookeeper-operator for SDP 25.7.0
        25.7.0-arm64
        25.7.0-amd64
        25.7.0
Checking sdp/airflow@2.9.3 for SDP 25.7.0
        2.9.3-stackable25.7.0-arm64
        2.9.3-stackable25.7.0-amd64
        2.9.3-stackable25.7.0
Checking sdp/airflow@2.10.4 for SDP 25.7.0
        2.10.4-stackable25.7.0-arm64
        2.10.4-stackable25.7.0-amd64
        2.10.4-stackable25.7.0
Checking sdp/airflow@2.10.5 for SDP 25.7.0
        2.10.5-stackable25.7.0-arm64
        2.10.5-stackable25.7.0-amd64
        2.10.5-stackable25.7.0
Checking sdp/airflow@3.0.1 for SDP 25.7.0
        3.0.1-stackable25.7.0-arm64
        3.0.1-stackable25.7.0-amd64
        3.0.1-stackable25.7.0
Checking sdp/druid@30.0.1 for SDP 25.7.0
        30.0.1-stackable25.7.0-arm64
        30.0.1-stackable25.7.0-amd64
        30.0.1-stackable25.7.0
Checking sdp/druid@31.0.1 for SDP 25.7.0
        31.0.1-stackable25.7.0-arm64
        31.0.1-stackable25.7.0-amd64
        31.0.1-stackable25.7.0
Checking sdp/druid@33.0.0 for SDP 25.7.0
        33.0.0-stackable25.7.0-arm64
        33.0.0-stackable25.7.0-amd64
        33.0.0-stackable25.7.0
Checking sdp/hadoop@3.3.6 for SDP 25.7.0
        3.3.6-stackable25.7.0-arm64
        3.3.6-stackable25.7.0-amd64
        3.3.6-stackable25.7.0
Checking sdp/hadoop@3.4.1 for SDP 25.7.0
        3.4.1-stackable25.7.0-arm64
        3.4.1-stackable25.7.0-amd64
        3.4.1-stackable25.7.0
Checking sdp/hbase@2.6.1 for SDP 25.7.0
        2.6.1-stackable25.7.0-arm64
        2.6.1-stackable25.7.0-amd64
        2.6.1-stackable25.7.0
Checking sdp/hbase@2.6.2 for SDP 25.7.0
        2.6.2-stackable25.7.0-arm64
        2.6.2-stackable25.7.0-amd64
        2.6.2-stackable25.7.0
Checking sdp/hive@3.1.3 for SDP 25.7.0
        3.1.3-stackable25.7.0-arm64
        3.1.3-stackable25.7.0-amd64
        3.1.3-stackable25.7.0
Checking sdp/hive@4.0.0 for SDP 25.7.0
        4.0.0-stackable25.7.0-arm64
        4.0.0-stackable25.7.0-amd64
        4.0.0-stackable25.7.0
Checking sdp/hive@4.0.1 for SDP 25.7.0
        4.0.1-stackable25.7.0-arm64
        4.0.1-stackable25.7.0-amd64
        4.0.1-stackable25.7.0
Checking sdp/kafka-testing-tools@1.0.0 for SDP 25.7.0
        1.0.0-stackable25.7.0-arm64
        1.0.0-stackable25.7.0-amd64
        1.0.0-stackable25.7.0
Checking sdp/kafka@3.7.2 for SDP 25.7.0
        3.7.2-stackable25.7.0-arm64
        3.7.2-stackable25.7.0-amd64
        3.7.2-stackable25.7.0
Checking sdp/kafka@3.9.0 for SDP 25.7.0
        3.9.0-stackable25.7.0-arm64
        3.9.0-stackable25.7.0-amd64
        3.9.0-stackable25.7.0
Checking sdp/kafka@3.9.1 for SDP 25.7.0
        3.9.1-stackable25.7.0-arm64
        3.9.1-stackable25.7.0-amd64
        3.9.1-stackable25.7.0
Checking sdp/kafka@4.0.0 for SDP 25.7.0
        4.0.0-stackable25.7.0-arm64
        4.0.0-stackable25.7.0-amd64
        4.0.0-stackable25.7.0
Checking sdp/krb5@1.21.1 for SDP 25.7.0
        1.21.1-stackable25.7.0-arm64
        1.21.1-stackable25.7.0-amd64
        1.21.1-stackable25.7.0
Checking sdp/nifi@1.27.0 for SDP 25.7.0
        1.27.0-stackable25.7.0-arm64
        1.27.0-stackable25.7.0-amd64
        1.27.0-stackable25.7.0
Checking sdp/nifi@1.28.1 for SDP 25.7.0
        1.28.1-stackable25.7.0-arm64
        1.28.1-stackable25.7.0-amd64
        1.28.1-stackable25.7.0
Checking sdp/nifi@2.4.0 for SDP 25.7.0
        2.4.0-stackable25.7.0-arm64
        2.4.0-stackable25.7.0-amd64
        2.4.0-stackable25.7.0
Checking sdp/omid@1.1.2 for SDP 25.7.0
        1.1.2-stackable25.7.0-arm64
        1.1.2-stackable25.7.0-amd64
        1.1.2-stackable25.7.0
Checking sdp/omid@1.1.3 for SDP 25.7.0
        1.1.3-stackable25.7.0-arm64
        1.1.3-stackable25.7.0-amd64
        1.1.3-stackable25.7.0
Checking sdp/opa@1.4.2 for SDP 25.7.0
        1.4.2-stackable25.7.0-arm64
        1.4.2-stackable25.7.0-amd64
        1.4.2-stackable25.7.0
Checking sdp/opa@1.0.1 for SDP 25.7.0
        1.0.1-stackable25.7.0-arm64
        1.0.1-stackable25.7.0-amd64
        1.0.1-stackable25.7.0
Checking stackable/spark-connect-client@3.5.6 for SDP 25.7.0
        3.5.6-stackable25.7.0-arm64
        3.5.6-stackable25.7.0-amd64
        3.5.6-stackable25.7.0
Checking sdp/spark-k8s@3.5.5 for SDP 25.7.0
        3.5.5-stackable25.7.0-arm64
        3.5.5-stackable25.7.0-amd64
        3.5.5-stackable25.7.0
Checking sdp/spark-k8s@3.5.6 for SDP 25.7.0
        3.5.6-stackable25.7.0-arm64
        3.5.6-stackable25.7.0-amd64
        3.5.6-stackable25.7.0
Checking sdp/superset@4.0.2 for SDP 25.7.0
        4.0.2-stackable25.7.0-arm64
        4.0.2-stackable25.7.0-amd64
        4.0.2-stackable25.7.0
Checking sdp/superset@4.1.1 for SDP 25.7.0
        4.1.1-stackable25.7.0-arm64
        4.1.1-stackable25.7.0-amd64
        4.1.1-stackable25.7.0
Checking sdp/superset@4.1.2 for SDP 25.7.0
        4.1.2-stackable25.7.0-arm64
        4.1.2-stackable25.7.0-amd64
        4.1.2-stackable25.7.0
Checking sdp/tools@1.0.0 for SDP 25.7.0
        1.0.0-stackable25.7.0-arm64
        1.0.0-stackable25.7.0-amd64
        1.0.0-stackable25.7.0
Checking sdp/trino@451 for SDP 25.7.0
        451-stackable25.7.0-arm64
        451-stackable25.7.0-amd64
        451-stackable25.7.0
Checking sdp/trino@470 for SDP 25.7.0
        470-stackable25.7.0-arm64
        470-stackable25.7.0-amd64
        470-stackable25.7.0
Checking sdp/trino@476 for SDP 25.7.0
        476-stackable25.7.0-arm64
        476-stackable25.7.0-amd64
        476-stackable25.7.0
Checking sdp/vector@0.47.0 for SDP 25.7.0
        0.47.0-stackable25.7.0-arm64
        0.47.0-stackable25.7.0-amd64
        0.47.0-stackable25.7.0
Checking sdp/zookeeper@3.9.3 for SDP 25.7.0
        3.9.3-stackable25.7.0-arm64
        3.9.3-stackable25.7.0-amd64
        3.9.3-stackable25.7.0
```

</details>
